### PR TITLE
Checkout to r2092 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 
 .PHONY: electricdss
 electricdss: $(OPENDSS_DIR)
-	svn update $<
+	svn update -r r2092 $<
 	cd $(OPENDSS_LIB) && mkdir -p units && $(CC) $(CFLAGS) $(LDFLAGS) -Fl$(KLUSOLVE_DLL) $(OPENDSS_PROJ)
 ifeq ($(UNAME_S),Darwin)
 	install_name_tool -id @rpath/$(OPENDSS_OUT)$(LIB_SUFFIX) $(OPENDSS_LIB)$(OPENDSS_OUT)$(LIB_SUFFIX)


### PR DESCRIPTION
Because currently DDLL is failing to compile in Linux, checkout
to the most recent tag (r2092) which builds correctly