### PR TITLE
WIP: Uses Free Pascal from Linux distribution instead the upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,23 +136,7 @@ reset: clean_all
 .PHONY: setup
 setup:
 ifeq ($(UNAME_S),Linux)
-	sudo apt install build-essential subversion fp-compiler
-FPC_VERSION := $(shell fpc -iV)
-	ifeq (, $(findstring 3., $(FPC_VERSION)))
-		ifeq ($(ARCH_S),x86_64)
-			@ sudo ln -sfv /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so
-			@ sudo ln -sfv /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so
-			@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.x86_64-linux.tar  && \
-			tar -xvf fpc-3.0.2.x86_64-linux.tar && \
-			cd fpc-3.0.2.x86_64-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
-		else ifeq ($(ARCH_S),i686)
-			@ sudo ln -sfv /usr/lib/i386-linux-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so
-			@ sudo ln -sfv /lib/i386-linux-gnu/libgcc_s.so.1 /lib/i386-linux-gnu/libgcc_s.so
-			@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.i386-linux.tar  && \
-			tar -xvf fpc-3.0.2.i386-linux.tar && \
-			cd fpc-3.0.2.i386-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
-		endif
-	endif
+	sudo apt install build-essential subversion fpc
 else ifeq ($(UNAME_S).$(ARCH_S),Darwin.x86_64)
 	brew update
 	command -v fpc >/dev/null 2>&1 && brew upgrade fpc || brew install fpc

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,22 @@ reset: clean_all
 setup:
 ifeq ($(UNAME_S),Linux)
 	sudo apt install build-essential subversion fp-compiler
+FPC_VERSION := $(shell fpc -iV)
+	ifeq (, $(findstring 3., $(FPC_VERSION)))
+		ifeq ($(ARCH_S),x86_64)
+			@ sudo ln -sfv /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so
+			@ sudo ln -sfv /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so
+			@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.x86_64-linux.tar  && \
+			tar -xvf fpc-3.0.2.x86_64-linux.tar && \
+			cd fpc-3.0.2.x86_64-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
+		else ifeq ($(ARCH_S),i686)
+			@ sudo ln -sfv /usr/lib/i386-linux-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so
+			@ sudo ln -sfv /lib/i386-linux-gnu/libgcc_s.so.1 /lib/i386-linux-gnu/libgcc_s.so
+			@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.i386-linux.tar  && \
+			tar -xvf fpc-3.0.2.i386-linux.tar && \
+			cd fpc-3.0.2.i386-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
+		endif
+	endif
 else ifeq ($(UNAME_S).$(ARCH_S),Darwin.x86_64)
 	brew update
 	command -v fpc >/dev/null 2>&1 && brew upgrade fpc || brew install fpc

--- a/Makefile
+++ b/Makefile
@@ -135,31 +135,12 @@ reset: clean_all
 
 .PHONY: setup
 setup:
-ifeq ($(UNAME_S).$(ARCH_S),Linux.x86_64)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so
-	@ sudo ln -sfv /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so
-	@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.x86_64-linux.tar  && \
-	tar -xvf fpc-3.0.2.x86_64-linux.tar && \
-	cd fpc-3.0.2.x86_64-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
-else ifeq ($(UNAME_S).$(ARCH_S),Linux.i686)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/i386-linux-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so
-	@ sudo ln -sfv /lib/i386-linux-gnu/libgcc_s.so.1 /lib/i386-linux-gnu/libgcc_s.so
-	@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.i386-linux.tar  && \
-	tar -xvf fpc-3.0.2.i386-linux.tar && \
-	cd fpc-3.0.2.i386-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
+ifeq ($(UNAME_S),Linux)
+	sudo apt install build-essential subversion fp-compiler
 else ifeq ($(UNAME_S).$(ARCH_S),Darwin.x86_64)
 	brew update
 	command -v fpc >/dev/null 2>&1 && brew upgrade fpc || brew install fpc
 	command -v svn >/dev/null 2>&1 && brew upgrade subversion || brew install subversion
-else ifneq ($(findstring arm,$(ARCH_S)),)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libstdc++.so.6 /usr/lib/arm-linux-gnueabihf/libstdc++.so
-	@ sudo ln -sfv /lib/arm-linux-gnueabihf/libgcc_s.so.1 /lib/arm-linux-gnueabihf/libgcc_s.so
-	@ wget ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.0.2/arm-linux/fpc-3.0.2.arm-linux-eabihf-raspberry.tar && \
-	tar -xvf fpc-3.0.2.arm-linux-eabihf-raspberry.tar && \
-	cd fpc-3.0.2.arm-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
 else
 	$(error Architecture $(ARCH_S) on $(UNAME_S) not supported for `make setup`)
 endif


### PR DESCRIPTION
Currently the project is downloading and building an upstream
version of Free Pascal. The script can use the Pascal compiler
provide from the Linux distribution instead.

Using the package manage tool from distribution, it is not
necessary to verify the architecture of the OS to use the
correct Free Pascal version. Package manager can resolve it
for the script.

Let's see if CI builds it correctly :)
This pull request is related to #25