### PR TITLE
Test the unnoficial Xenial support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: ruby
+language: c
 sudo: required
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: required
 os:
   - linux
+    dist: xenial
   - osx
 before_script:
   - make setup

--- a/Makefile
+++ b/Makefile
@@ -135,31 +135,12 @@ reset: clean_all
 
 .PHONY: setup
 setup:
-ifeq ($(UNAME_S).$(ARCH_S),Linux.x86_64)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so
-	@ sudo ln -sfv /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so
-	@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.x86_64-linux.tar  && \
-	tar -xvf fpc-3.0.2.x86_64-linux.tar && \
-	cd fpc-3.0.2.x86_64-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
-else ifeq ($(UNAME_S).$(ARCH_S),Linux.i686)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/i386-linux-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so
-	@ sudo ln -sfv /lib/i386-linux-gnu/libgcc_s.so.1 /lib/i386-linux-gnu/libgcc_s.so
-	@ wget https://sourceforge.net/projects/freepascal/files/Linux/3.0.2/fpc-3.0.2.i386-linux.tar  && \
-	tar -xvf fpc-3.0.2.i386-linux.tar && \
-	cd fpc-3.0.2.i386-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
+ifeq ($(UNAME_S),Linux)
+	sudo apt install build-essential subversion fp-compiler
 else ifeq ($(UNAME_S).$(ARCH_S),Darwin.x86_64)
 	brew update
 	command -v fpc >/dev/null 2>&1 && brew upgrade fpc || brew install fpc
 	command -v svn >/dev/null 2>&1 && brew upgrade subversion || brew install subversion
-else ifneq ($(findstring arm,$(ARCH_S)),)
-	sudo apt install build-essential subversion
-	@ sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libstdc++.so.6 /usr/lib/arm-linux-gnueabihf/libstdc++.so
-	@ sudo ln -sfv /lib/arm-linux-gnueabihf/libgcc_s.so.1 /lib/arm-linux-gnueabihf/libgcc_s.so
-	@ wget ftp://ftp.hu.freepascal.org/pub/fpc/dist/3.0.2/arm-linux/fpc-3.0.2.arm-linux-eabihf-raspberry.tar && \
-	tar -xvf fpc-3.0.2.arm-linux-eabihf-raspberry.tar && \
-	cd fpc-3.0.2.arm-linux && sudo ./install.sh </dev/null && cd .. && rm -rf fpc*
 else
 	$(error Architecture $(ARCH_S) on $(UNAME_S) not supported for `make setup`)
 endif


### PR DESCRIPTION
This pull request will test the unnoficial Xenial support in Travis as pointed in https://github.com/travis-ci/travis-ci/issues/7260#issuecomment-354350596.

Currently, OpenDSSDirect requires fpc 3 to compile, but Ubuntu Trusty OS has only fpc 2 version.